### PR TITLE
Refactor Rifm into useRifm hook and Rifm component

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 9229,
-    "minified": 2301,
-    "gzipped": 1099
+    "bundled": 8775,
+    "minified": 2150,
+    "gzipped": 1030
   },
   "dist/rifm.min.js": {
-    "bundled": 8456,
-    "minified": 1895,
-    "gzipped": 928
+    "bundled": 8002,
+    "minified": 1744,
+    "gzipped": 861
   },
   "dist/rifm.cjs.js": {
-    "bundled": 8710,
-    "minified": 2366,
-    "gzipped": 1095
+    "bundled": 8284,
+    "minified": 2152,
+    "gzipped": 1007
   },
   "dist/rifm.esm.js": {
-    "bundled": 8621,
-    "minified": 2283,
-    "gzipped": 1059,
+    "bundled": 8195,
+    "minified": 2073,
+    "gzipped": 961,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 7753,
-    "minified": 1747,
-    "gzipped": 838,
+    "bundled": 7327,
+    "minified": 1537,
+    "gzipped": 736,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/rifm.umd.js": {
-    "bundled": 8499,
-    "minified": 2012,
-    "gzipped": 994
+    "bundled": 9229,
+    "minified": 2301,
+    "gzipped": 1099
   },
   "dist/rifm.min.js": {
-    "bundled": 7864,
-    "minified": 1693,
-    "gzipped": 843
+    "bundled": 8456,
+    "minified": 1895,
+    "gzipped": 928
   },
   "dist/rifm.cjs.js": {
-    "bundled": 8026,
-    "minified": 1978,
-    "gzipped": 974
+    "bundled": 8710,
+    "minified": 2366,
+    "gzipped": 1095
   },
   "dist/rifm.esm.js": {
-    "bundled": 7955,
-    "minified": 1915,
-    "gzipped": 933,
+    "bundled": 8621,
+    "minified": 2283,
+    "gzipped": 1059,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -29,9 +29,9 @@
     }
   },
   "dist/rifm.esm.production.js": {
-    "bundled": 7217,
-    "minified": 1482,
-    "gzipped": 723,
+    "bundled": 7753,
+    "minified": 1747,
+    "gzipped": 838,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RIFM - React Input Format & Mask
 
-Is a tiny (≈ 800b) component to transform any input component
+Is a tiny (≈ 800b) component (and hook) to transform any input component
 into formatted or masked input.
 
 [Demo](https://realadvisor.github.io/rifm)
@@ -17,6 +17,10 @@ into formatted or masked input.
 - flow + typescript definitions
 
 ## Example
+
+Rifm offers both a Render Prop and a Hook API:
+
+### Render Prop
 
 ```js
 import { Rifm } from 'rifm';
@@ -47,6 +51,42 @@ const numberFormat = (str: string) => {
       />
     )}
   </Rifm>
+
+...
+```
+
+### Hook
+
+```js
+import { useRifm } from 'rifm';
+import TextField from '@material-ui/core/TextField';
+import { css } from 'emotion';
+
+const numberFormat = (str: string) => {
+  const r = parseInt(str.replace(/[^\d]+/gi, ''), 10);
+  return r ? r.toLocaleString('en') : '';
+}
+
+...
+
+  const [value, setValue] = React.useState('')
+
+  const {
+    value,
+    onChange,
+  } = useRifm({
+    value,
+    onChange: setValue,
+    format: numberFormat
+  })
+
+  <TextField
+    value={value}
+    label={'Float'}
+    onChange={onChange}
+    className={css({input: {textAlign:"right"}})}
+    type="tel"
+  />
 
 ...
 ```
@@ -92,7 +132,9 @@ This operation works well if you need to change input value without loosing curs
 
 And finaly masks - masks are usually is format with replace editing mode + some small cursor visual hacks.
 
-### Props
+### Input Props
+
+These are accepted by the Rifm component as props and the useRifm hook as named arguments.
 
 | Prop         | type                          | default | Description                                                                                                                                                   |
 | ------------ | :---------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -104,6 +146,15 @@ And finaly masks - masks are usually is format with replace editing mode + some 
 | **mask**     | boolean (optional)            |         | use replace input mode if true, use cursor visual hacks if prop provided                                                                                      |
 | **replace**  | string => string (optional)   |         | format postprocessor allows you to fully replace any/all symbol/s preserving cursor                                                                           |
 | **append**   | string => string (optional)   |         | format postprocessor called only if cursor is in the last position and new symbols added, used for specific use-case to add non accepted symbol when you type |
+
+### Output Props
+
+These will be passed into the `children` render prop for the Rifm component as named arguments, and returned from the useRifm hook as an object.
+
+| Prop         | type                   | default | Description                                                      |
+| ------------ | :--------------------- | :------ | :--------------------------------------------------------------- |
+| **value**    | string                 |         | A formatted string value to pass as a prop to your input element |
+| **onChange** | SyntheticEvent => void |         | The change handler to pass as a prop to your input element       |
 
 See the [Demo](https://realadvisor.github.io/rifm) there are a lot of examples there.
 

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-type Props = {|
+type Args = {|
   value: string,
   onChange: string => void,
   format: (str: string) => string,
@@ -10,15 +10,21 @@ type Props = {|
   replace?: string => string,
   append?: string => string,
   accept?: RegExp,
-  children: ({
-    value: string,
-    onChange: (
-      evt: SyntheticInputEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => void,
-  }) => React.Node,
 |};
 
-export const Rifm = (props: Props) => {
+type RenderProps = {|
+  value: string,
+  onChange: (
+    evt: SyntheticInputEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void,
+|};
+
+type Props = {|
+  ...Args,
+  children: RenderProps => React.Node,
+|};
+
+export const useRifm = (props: Args): RenderProps => {
   const [, refresh] = React.useReducer(c => c + 1, 0);
   const valueRef = React.useRef(null);
   const { replace, append } = props;
@@ -40,9 +46,7 @@ export const Rifm = (props: Props) => {
         return;
       }
       if (evt.target.type === 'date') {
-        console.error(
-          'Rifm does not support input type=date.'
-        );
+        console.error('Rifm does not support input type=date.');
         return;
       }
     }
@@ -228,8 +232,14 @@ export const Rifm = (props: Props) => {
     };
   }, []);
 
-  return props.children({
+  return {
     value: valueRef.current != null ? valueRef.current[0] : userValue,
     onChange,
-  });
+  };
+};
+
+export const Rifm = ({ children, ...args }: Props) => {
+  const renderProps = useRifm(args);
+
+  return children(renderProps);
 };

--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -238,8 +238,8 @@ export const useRifm = (props: Args): RenderProps => {
   };
 };
 
-export const Rifm = ({ children, ...args }: Props) => {
-  const renderProps = useRifm(args);
+export const Rifm = (props: Props) => {
+  const renderProps = useRifm((props: any));
 
-  return children(renderProps);
+  return props.children(renderProps);
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
 
-interface RifmRenderArgs<E> {
-  value: string;
-  onChange: React.ChangeEventHandler<E>;
-}
-
-interface RifmProps<E> {
+interface RifmArgs {
   value: string;
   onChange: (str: string) => void;
   format: (str: string) => string;
@@ -13,11 +8,23 @@ interface RifmProps<E> {
   append?: (str: string) => string;
   mask?: boolean;
   accept?: RegExp;
+}
+
+interface RifmRenderArgs<E> {
+  value: string;
+  onChange: React.ChangeEventHandler<E>;
+}
+
+interface RifmProps<E> extends RifmArgs {
   children: (args: RifmRenderArgs<E>) => React.ReactNode;
 }
+
+declare function useRifm<E = HTMLInputElement>(
+  args: RifmArgs
+): RifmRenderArgs<E>;
 
 declare class Rifm<E = HTMLInputElement> extends React.Component<
   RifmProps<E>
 > {}
 
-export { Rifm };
+export { useRifm, Rifm };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 /* @flow */
 
-export { Rifm } from './Rifm';
+export { useRifm, Rifm } from './Rifm';


### PR DESCRIPTION
To address #38 

Happy to add some tests specifically for the hook if desired, but it 
didn't feel super vital atm as all the code paths in the hook are exercised 
by the existing render props tests.

Also happy to help in updating docs as well.

I have these changes currently published as @lewisl9029/rifm@0.02 in case anyone wants to try it out.