### PR TITLE
Fix cursor position after delete with multiple non-accepted chars after

### DIFF
--- a/src/Rifm.js
+++ b/src/Rifm.js
@@ -100,6 +100,15 @@ export const useRifm = (props: Args): RenderProps => {
       // in case of isDeleleteButtonDown cursor should move differently vs backspace
       const deleteWasNoOp = isDeleleteButtonDown && isNoOperation;
 
+      const valueAfterSelectionStart = eventValue.slice(input.selectionStart);
+
+      const acceptedCharIndexAfterDelete = valueAfterSelectionStart.search(
+        props.accept || /\d/g
+      );
+
+      const charsToSkipAfterDelete =
+        acceptedCharIndexAfterDelete !== -1 ? acceptedCharIndexAfterDelete : 0;
+
       // Create string from only accepted symbols
       const clean = str => (str.match(props.accept || /\d/g) || []).join('');
 
@@ -200,7 +209,7 @@ export const useRifm = (props: Args): RenderProps => {
         }
 
         input.selectionStart = input.selectionEnd =
-          start + (deleteWasNoOp ? 1 : 0);
+          start + (deleteWasNoOp ? 1 + charsToSkipAfterDelete : 0);
       };
     });
   }

--- a/tests/RifmFormat.test.js
+++ b/tests/RifmFormat.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { formatFixedPointNumber, formatFloatingPointNumber } from './format';
+import { formatFixedPointNumber, formatFloatingPointNumber, formatPhone } from './format';
 import { createExec } from './utils/exec';
 
 test('format works', async () => {
@@ -154,4 +154,15 @@ it('replace is applied to input value', () => {
   });
 
   exec({ type: 'MOVE_CARET', payload: -5 }).toMatchInlineSnapshot(`"|hello"`);
+});
+
+it('moves cursor to expected position when deleting with more than 1 non-accepted chars after cursor', () => {
+  const exec = createExec({
+    format: formatPhone,
+    accept: /\d+/g,
+    initialValue: '1 (234) 567',
+  });
+
+  exec({ type: 'MOVE_CARET', payload: 6 }).toMatchInlineSnapshot(`"1 (234|) 567"`);
+  exec({ type: 'DELETE' }).toMatchInlineSnapshot(`"1 (234) |567"`);
 });


### PR DESCRIPTION
Hi! I just recently noticed a bug with using Rifm with phone formatting. It can be reproduced in the official example as well: 

https://realadvisor.github.io/rifm/

![May-21-2020 16-08-43](https://user-images.githubusercontent.com/6934200/82614789-86065280-9b7d-11ea-919e-99dfdc70bdca.gif)

When we try to delete right before a string of multiple non-accepted characters (in this case it's the `) ` part), the cursor only moves forward by 1 character, and subsequent deletes end up doing nothing, causing the user to be stuck.

Here's my first attempt at a fix and a test to cover this case. Let me know if there's anything you'd like to see changed, I suspect there might be some nuance I might be missing in the implementation.

Another gif of what the new behavior looks like in action: 
![May-21-2020 16-16-15](https://user-images.githubusercontent.com/6934200/82615123-7c311f00-9b7e-11ea-8c30-f3c6394fc631.gif)
